### PR TITLE
Phase 4: fullscreen, sticky UI, drag handles, gifts polish, collapsible tree

### DIFF
--- a/lib/features/export/services/export_content_builder.dart
+++ b/lib/features/export/services/export_content_builder.dart
@@ -44,8 +44,10 @@ class ExportContentBuilder {
   }
 
   static ShareableContent? spiritualGifts(AppLocalizations l10n, SpiritualGiftsState state) {
-    final topThree = state.getRankedGifts().take(3).toList();
+    final rankedGifts = state.getRankedGifts();
+    final topThree = rankedGifts.take(3).toList();
     if (topThree.isEmpty) return null;
+    final dormant = rankedGifts.skip(3).take(3).toList();
     final scores = state.getScoresPerGift();
 
     return ShareableContent(
@@ -68,6 +70,14 @@ class ExportContentBuilder {
                       '(${l10n.giftsScorePoints(scores[topThree[i].id] ?? 0)})',
                   'body': topThree[i].description,
                 },
+              if (dormant.isNotEmpty) ...[
+                {'title': l10n.giftsDormantHeading, 'body': l10n.giftsDormantGuidance},
+                for (final gift in dormant)
+                  {
+                    'title': '${gift.name} (${l10n.giftsScorePoints(scores[gift.id] ?? 0)})',
+                    'body': gift.description,
+                  },
+              ],
             ],
           },
         ),

--- a/lib/features/life_tree/widgets/life_tree_editor.dart
+++ b/lib/features/life_tree/widgets/life_tree_editor.dart
@@ -375,6 +375,14 @@ class _LifeTreeGraphViewOnlyState extends State<_LifeTreeGraphViewOnly> with Tic
               graph: graph,
               algorithm: algorithm,
               controller: _graphController,
+              // Die eingebaute Fade-/Positions-Animation von graphview
+              // interpoliert bei jedem Neu-Layout (z.B. nach Hinzufügen eines
+              // Knotens) zwischen alter und neuer Position; bei frisch
+              // hinzugekommenen Knoten ohne vorherige Position führte das zu
+              // NaN-Werten und einem kompletten Render-Absturz (Geburtsknoten
+              // verschwand). Collapse/Expand funktioniert auch ohne
+              // Animation einwandfrei, daher hier deaktiviert.
+              animated: false,
               paint: Paint()..color = Colors.green.shade400..strokeWidth = 1.5..style = PaintingStyle.stroke,
               builder: (Node node) {
                 final nodeId = node.key?.value as String;
@@ -387,7 +395,7 @@ class _LifeTreeGraphViewOnlyState extends State<_LifeTreeGraphViewOnly> with Tic
                   autofocus: nodeId == _lastAddedNodeId,
                   hasChildren: hasChildren,
                   isCollapsed: hasChildren && _graphController.isNodeCollapsed(node),
-                  onToggleCollapse: () => _graphController.toggleNodeExpanded(graph, node, animate: true),
+                  onToggleCollapse: () => _graphController.toggleNodeExpanded(graph, node),
                   onChanged: (text) => widget.onUpdateText(nodeId, text),
                   onNoteChanged: (note) => widget.onUpdateNote(nodeId, note),
                   onAddChild: () => widget.onAddNode(nodeId, ''),

--- a/lib/features/life_tree/widgets/life_tree_editor.dart
+++ b/lib/features/life_tree/widgets/life_tree_editor.dart
@@ -96,7 +96,7 @@ class _LifeTreeGraphSectionState extends State<_LifeTreeGraphSection> {
     Navigator.of(context).push(
       MaterialPageRoute(
         builder: (context) => _FullscreenGraphViewer(
-          nodes: widget.nodes,
+          sessionId: widget.sessionId,
           onAddNode: widget.onAddNode,
           onUpdateText: widget.onUpdateText,
           onUpdateNote: widget.onUpdateNote,
@@ -393,7 +393,7 @@ class _LifeTreeGraphViewOnlyState extends State<_LifeTreeGraphViewOnly> with Tic
 }
 
 class _FullscreenGraphViewer extends StatefulWidget {
-  final List<LifeTreeNodeData> nodes;
+  final String sessionId;
   final Function(String?, String) onAddNode;
   final Function(String, String) onUpdateText;
   final Function(String, String) onUpdateNote;
@@ -401,7 +401,7 @@ class _FullscreenGraphViewer extends StatefulWidget {
   final Matrix4 initialMatrix;
 
   const _FullscreenGraphViewer({
-    required this.nodes,
+    required this.sessionId,
     required this.onAddNode,
     required this.onUpdateText,
     required this.onUpdateNote,
@@ -449,13 +449,25 @@ class _FullscreenGraphViewerState extends State<_FullscreenGraphViewer> {
       ),
       body: Container(
         color: Colors.white,
-        child: _LifeTreeGraphViewOnly(
-          nodes: widget.nodes,
-          onAddNode: widget.onAddNode,
-          onUpdateText: widget.onUpdateText,
-          onUpdateNote: widget.onUpdateNote,
-          onDeleteNode: widget.onDeleteNode,
-          transformationController: _transformationController,
+        // Wichtig: dieser Screen wird per Navigator.push in einer eigenen
+        // Route gebaut, die außerhalb des BlocBuilder-Baums des normalen
+        // Editors liegt. Ohne einen eigenen BlocBuilder hier blieb die
+        // Knotenliste auf dem Stand beim Öffnen des Vollbildmodus eingefroren
+        // - Kind/Geschwister hinzufügen speicherte zwar korrekt (sichtbar
+        // erst nach Verlassen), aber die Vollbild-Ansicht selbst rendert nie
+        // neu (#61).
+        child: BlocBuilder<LifeTreeBloc, EntryListState>(
+          builder: (context, state) {
+            final nodes = (state as LifeTreeState).treeNodes[widget.sessionId] ?? const [];
+            return _LifeTreeGraphViewOnly(
+              nodes: nodes,
+              onAddNode: widget.onAddNode,
+              onUpdateText: widget.onUpdateText,
+              onUpdateNote: widget.onUpdateNote,
+              onDeleteNode: widget.onDeleteNode,
+              transformationController: _transformationController,
+            );
+          },
         ),
       ),
     );

--- a/lib/features/life_tree/widgets/life_tree_editor.dart
+++ b/lib/features/life_tree/widgets/life_tree_editor.dart
@@ -203,12 +203,6 @@ class _LifeTreeGraphViewOnlyState extends State<_LifeTreeGraphViewOnly> with Tic
   late BuchheimWalkerConfiguration builder;
   late Algorithm algorithm;
   final Map<String, Node> _nodeCache = {};
-  // Ein-/Ausklappen von Teilbäumen (#55) - rein visueller Zustand für diese
-  // Betrachtungs-Session, wirkt sich nicht auf die gespeicherten Baumdaten
-  // aus. Das graphview-Paket bringt Collapse/Expand bereits fertig mit
-  // (Sichtbarkeits-/Fade-Logik), dafür muss GraphView.builder() statt der
-  // einfachen GraphView()-Variante genutzt werden.
-  final GraphViewController _graphController = GraphViewController();
   late TransformationController _transformationController;
   late AnimationController _animationController;
   Animation<Matrix4>? _animation;
@@ -371,31 +365,18 @@ class _LifeTreeGraphViewOnlyState extends State<_LifeTreeGraphViewOnly> with Tic
           child: Container(
             color: Colors.white,
             padding: const EdgeInsets.symmetric(horizontal: 200, vertical: 50),
-            child: GraphView.builder(
+            child: GraphView(
               graph: graph,
               algorithm: algorithm,
-              controller: _graphController,
-              // Die eingebaute Fade-/Positions-Animation von graphview
-              // interpoliert bei jedem Neu-Layout (z.B. nach Hinzufügen eines
-              // Knotens) zwischen alter und neuer Position; bei frisch
-              // hinzugekommenen Knoten ohne vorherige Position führte das zu
-              // NaN-Werten und einem kompletten Render-Absturz (Geburtsknoten
-              // verschwand). Collapse/Expand funktioniert auch ohne
-              // Animation einwandfrei, daher hier deaktiviert.
-              animated: false,
               paint: Paint()..color = Colors.green.shade400..strokeWidth = 1.5..style = PaintingStyle.stroke,
               builder: (Node node) {
                 final nodeId = node.key?.value as String;
                 final nodeData = widget.nodes.firstWhere((n) => n.id == nodeId, orElse: () => LifeTreeNodeData(id: nodeId, text: '...'));
-                final hasChildren = widget.nodes.any((n) => n.parentId == nodeId);
 
                 return _TreeNodeWidget(
                   key: ValueKey('node_wid_$nodeId'),
                   nodeData: nodeData,
                   autofocus: nodeId == _lastAddedNodeId,
-                  hasChildren: hasChildren,
-                  isCollapsed: hasChildren && _graphController.isNodeCollapsed(node),
-                  onToggleCollapse: () => _graphController.toggleNodeExpanded(graph, node),
                   onChanged: (text) => widget.onUpdateText(nodeId, text),
                   onNoteChanged: (note) => widget.onUpdateNote(nodeId, note),
                   onAddChild: () => widget.onAddNode(nodeId, ''),
@@ -496,9 +477,6 @@ class _FullscreenGraphViewerState extends State<_FullscreenGraphViewer> {
 class _TreeNodeWidget extends StatefulWidget {
   final LifeTreeNodeData nodeData;
   final bool autofocus;
-  final bool hasChildren;
-  final bool isCollapsed;
-  final VoidCallback onToggleCollapse;
   final ValueChanged<String> onChanged;
   final ValueChanged<String> onNoteChanged;
   final VoidCallback onAddChild;
@@ -509,9 +487,6 @@ class _TreeNodeWidget extends StatefulWidget {
     super.key,
     required this.nodeData,
     this.autofocus = false,
-    this.hasChildren = false,
-    this.isCollapsed = false,
-    required this.onToggleCollapse,
     required this.onChanged,
     required this.onNoteChanged,
     required this.onAddChild,
@@ -783,19 +758,6 @@ class _TreeNodeWidgetState extends State<_TreeNodeWidget> {
                     onTap: widget.onDelete,
                   ),
                 ),
-
-              // Ein-/Ausklappen von Teilbäumen (#55): bewusst immer sichtbar
-              // (nicht nur bei Hover wie die übrigen Buttons), damit erkennbar
-              // bleibt, dass hier weitere Knoten verborgen sind, auch ohne
-              // dass man gerade über den Knoten fährt.
-              if (widget.hasChildren)
-                Positioned(
-                  bottom: -12,
-                  child: _CollapseToggleButton(
-                    isCollapsed: widget.isCollapsed,
-                    onTap: widget.onToggleCollapse,
-                  ),
-                ),
             ],
           ),
         ),
@@ -830,34 +792,3 @@ class _GhostNodeButton extends StatelessWidget {
   }
 }
 
-/// Ein-/Ausklappen von Teilbäumen (#55): kleiner runder Button unterhalb
-/// eines Knotens mit Kindern, zeigt je nach Zustand + oder -.
-class _CollapseToggleButton extends StatelessWidget {
-  final bool isCollapsed;
-  final VoidCallback onTap;
-
-  const _CollapseToggleButton({required this.isCollapsed, required this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Material(
-      color: Colors.white,
-      shape: CircleBorder(side: BorderSide(color: theme.primaryColor.withValues(alpha: 0.5))),
-      elevation: 1,
-      child: InkWell(
-        customBorder: const CircleBorder(),
-        onTap: onTap,
-        child: SizedBox(
-          width: 24,
-          height: 24,
-          child: Icon(
-            isCollapsed ? Icons.add : Icons.remove,
-            size: 16,
-            color: theme.primaryColor,
-          ),
-        ),
-      ),
-    );
-  }
-}

--- a/lib/features/life_tree/widgets/life_tree_editor.dart
+++ b/lib/features/life_tree/widgets/life_tree_editor.dart
@@ -203,6 +203,12 @@ class _LifeTreeGraphViewOnlyState extends State<_LifeTreeGraphViewOnly> with Tic
   late BuchheimWalkerConfiguration builder;
   late Algorithm algorithm;
   final Map<String, Node> _nodeCache = {};
+  // Ein-/Ausklappen von Teilbäumen (#55) - rein visueller Zustand für diese
+  // Betrachtungs-Session, wirkt sich nicht auf die gespeicherten Baumdaten
+  // aus. Das graphview-Paket bringt Collapse/Expand bereits fertig mit
+  // (Sichtbarkeits-/Fade-Logik), dafür muss GraphView.builder() statt der
+  // einfachen GraphView()-Variante genutzt werden.
+  final GraphViewController _graphController = GraphViewController();
   late TransformationController _transformationController;
   late AnimationController _animationController;
   Animation<Matrix4>? _animation;
@@ -365,18 +371,23 @@ class _LifeTreeGraphViewOnlyState extends State<_LifeTreeGraphViewOnly> with Tic
           child: Container(
             color: Colors.white,
             padding: const EdgeInsets.symmetric(horizontal: 200, vertical: 50),
-            child: GraphView(
+            child: GraphView.builder(
               graph: graph,
               algorithm: algorithm,
+              controller: _graphController,
               paint: Paint()..color = Colors.green.shade400..strokeWidth = 1.5..style = PaintingStyle.stroke,
               builder: (Node node) {
                 final nodeId = node.key?.value as String;
                 final nodeData = widget.nodes.firstWhere((n) => n.id == nodeId, orElse: () => LifeTreeNodeData(id: nodeId, text: '...'));
-                
+                final hasChildren = widget.nodes.any((n) => n.parentId == nodeId);
+
                 return _TreeNodeWidget(
                   key: ValueKey('node_wid_$nodeId'),
                   nodeData: nodeData,
                   autofocus: nodeId == _lastAddedNodeId,
+                  hasChildren: hasChildren,
+                  isCollapsed: hasChildren && _graphController.isNodeCollapsed(node),
+                  onToggleCollapse: () => _graphController.toggleNodeExpanded(graph, node, animate: true),
                   onChanged: (text) => widget.onUpdateText(nodeId, text),
                   onNoteChanged: (note) => widget.onUpdateNote(nodeId, note),
                   onAddChild: () => widget.onAddNode(nodeId, ''),
@@ -477,6 +488,9 @@ class _FullscreenGraphViewerState extends State<_FullscreenGraphViewer> {
 class _TreeNodeWidget extends StatefulWidget {
   final LifeTreeNodeData nodeData;
   final bool autofocus;
+  final bool hasChildren;
+  final bool isCollapsed;
+  final VoidCallback onToggleCollapse;
   final ValueChanged<String> onChanged;
   final ValueChanged<String> onNoteChanged;
   final VoidCallback onAddChild;
@@ -487,6 +501,9 @@ class _TreeNodeWidget extends StatefulWidget {
     super.key,
     required this.nodeData,
     this.autofocus = false,
+    this.hasChildren = false,
+    this.isCollapsed = false,
+    required this.onToggleCollapse,
     required this.onChanged,
     required this.onNoteChanged,
     required this.onAddChild,
@@ -754,8 +771,21 @@ class _TreeNodeWidgetState extends State<_TreeNodeWidget> {
                   top: -8,
                   right: -8,
                   child: _GhostNodeButton(
-                    label: 'x', 
+                    label: 'x',
                     onTap: widget.onDelete,
+                  ),
+                ),
+
+              // Ein-/Ausklappen von Teilbäumen (#55): bewusst immer sichtbar
+              // (nicht nur bei Hover wie die übrigen Buttons), damit erkennbar
+              // bleibt, dass hier weitere Knoten verborgen sind, auch ohne
+              // dass man gerade über den Knoten fährt.
+              if (widget.hasChildren)
+                Positioned(
+                  bottom: -12,
+                  child: _CollapseToggleButton(
+                    isCollapsed: widget.isCollapsed,
+                    onTap: widget.onToggleCollapse,
                   ),
                 ),
             ],
@@ -786,6 +816,38 @@ class _GhostNodeButton extends StatelessWidget {
         child: Text(
           label,
           style: TextStyle(fontSize: 10, color: Colors.grey.shade700, fontWeight: FontWeight.bold),
+        ),
+      ),
+    );
+  }
+}
+
+/// Ein-/Ausklappen von Teilbäumen (#55): kleiner runder Button unterhalb
+/// eines Knotens mit Kindern, zeigt je nach Zustand + oder -.
+class _CollapseToggleButton extends StatelessWidget {
+  final bool isCollapsed;
+  final VoidCallback onTap;
+
+  const _CollapseToggleButton({required this.isCollapsed, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Material(
+      color: Colors.white,
+      shape: CircleBorder(side: BorderSide(color: theme.primaryColor.withValues(alpha: 0.5))),
+      elevation: 1,
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        onTap: onTap,
+        child: SizedBox(
+          width: 24,
+          height: 24,
+          child: Icon(
+            isCollapsed ? Icons.add : Icons.remove,
+            size: 16,
+            color: theme.primaryColor,
+          ),
         ),
       ),
     );

--- a/lib/features/spiritual_gifts/screens/spiritual_gifts_screen.dart
+++ b/lib/features/spiritual_gifts/screens/spiritual_gifts_screen.dart
@@ -46,6 +46,7 @@ class _SpiritualGiftsScreenState extends State<SpiritualGiftsScreen> {
     final l10n = AppLocalizations.of(context);
     final rankedGifts = state.getRankedGifts();
     final topThree = rankedGifts.take(3).toList();
+    final dormant = rankedGifts.skip(3).take(3).toList();
     final scores = state.getScoresPerGift();
     final takeaways = state.takeaways[widget.sessionId] ?? [];
 
@@ -53,7 +54,8 @@ class _SpiritualGiftsScreenState extends State<SpiritualGiftsScreen> {
 
     // Top 3 Gifts als eine gebrandete Bild-Karte statt einzelner Text-Zeilen (#24).
     // textValue liefert weiterhin eine Textzusammenfassung für die Nachricht,
-    // die zusammen mit dem Bild geteilt wird.
+    // die zusammen mit dem Bild geteilt wird. Latente Gaben (Rang 4-6) werden
+    // als eigener, klar abgesetzter Abschnitt in derselben Karte mitgeteilt (#59).
     if (topThree.isNotEmpty) {
       final giftTitles = [
         for (int i = 0; i < topThree.length; i++)
@@ -73,6 +75,14 @@ class _SpiritualGiftsScreenState extends State<SpiritualGiftsScreen> {
                     '(${l10n.giftsScorePoints(scores[topThree[i].id] ?? 0)})',
                 'body': topThree[i].description,
               },
+            if (dormant.isNotEmpty) ...[
+              {'title': l10n.giftsDormantHeading, 'body': l10n.giftsDormantGuidance},
+              for (final gift in dormant)
+                {
+                  'title': '${gift.name} (${l10n.giftsScorePoints(scores[gift.id] ?? 0)})',
+                  'body': gift.description,
+                },
+            ],
           ],
         },
       ));

--- a/lib/features/spiritual_gifts/widgets/spiritual_gifts_result.dart
+++ b/lib/features/spiritual_gifts/widgets/spiritual_gifts_result.dart
@@ -56,6 +56,18 @@ class SpiritualGiftsResult extends StatelessWidget {
                     ),
                     const SizedBox(height: 12),
                   ],
+                  // Es gibt insgesamt deutlich mehr als 6 Gaben (aktuell 18) -
+                  // ohne eigenen Abschluss lief die "Latente Gaben"-Sektion ab
+                  // Rang 7 optisch undifferenziert weiter, kaum vom Ende der
+                  // eigentlich nur 3 latenten Gaben (Rang 4-6) zu unterscheiden.
+                  if (index == 6) ...[
+                    const SizedBox(height: 20),
+                    Text(
+                      AppLocalizations.of(context).giftsOtherHeading,
+                      style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 12),
+                  ],
                   _GiftResultCard(
                     gift: gift,
                     score: score,

--- a/lib/features/spiritual_gifts/widgets/spiritual_gifts_result.dart
+++ b/lib/features/spiritual_gifts/widgets/spiritual_gifts_result.dart
@@ -33,19 +33,37 @@ class SpiritualGiftsResult extends StatelessWidget {
               ),
               const SizedBox(height: 24),
               
-              ...rankedGifts.asMap().entries.map((entry) {
+              ...rankedGifts.asMap().entries.expand((entry) {
                 final index = entry.key;
                 final gift = entry.value;
                 final score = scores[gift.id] ?? 0;
                 final isTop3 = index < 3;
 
-                return _GiftResultCard(
-                  gift: gift,
-                  score: score,
-                  rank: index + 1,
-                  isTop3: isTop3,
-                  maxScore: maxPossibleScore,
-                );
+                return [
+                  // Kurzer Abstand + eigene Überschrift zwischen den drei
+                  // Hauptgaben und den "latenten" Gaben (Rang 4-6), damit die
+                  // beiden Gruppen klar unterscheidbar sind (#59).
+                  if (index == 3) ...[
+                    const SizedBox(height: 20),
+                    Text(
+                      AppLocalizations.of(context).giftsDormantHeading,
+                      style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      AppLocalizations.of(context).giftsDormantGuidance,
+                      style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                    ),
+                    const SizedBox(height: 12),
+                  ],
+                  _GiftResultCard(
+                    gift: gift,
+                    score: score,
+                    rank: index + 1,
+                    isTop3: isTop3,
+                    maxScore: maxPossibleScore,
+                  ),
+                ];
               }),
               const SizedBox(height: 40),
             ],
@@ -133,6 +151,18 @@ class _GiftResultCard extends StatelessWidget {
                 minHeight: 6,
                 borderRadius: BorderRadius.circular(3),
               ),
+              // Kurzbeschreibung direkt sichtbar nur für die drei Hauptgaben
+              // (#59) - für die restlichen bleibt es beim Antippen für Details.
+              if (isTop3 && gift.description.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    gift.description,
+                    style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                  ),
+                ),
+              ],
             ],
           ),
         ),

--- a/lib/features/synthesis/widgets/synthesis_editor.dart
+++ b/lib/features/synthesis/widgets/synthesis_editor.dart
@@ -182,6 +182,11 @@ class _ConnectionsColumn extends StatelessWidget {
           ReorderableListView(
             shrinkWrap: true,
             physics: const NeverScrollableScrollPhysics(),
+            // Ohne dieses Flag hängt Flutter zusätzlich zum eigenen, bereits
+            // vorhandenen Handle vorne (Icons.drag_indicator) automatisch
+            // noch ein zweites Drag-Handle hinten an - App-weit einheitlich
+            // nur ein Handle vorne (#60).
+            buildDefaultDragHandles: false,
             onReorder: (oldIndex, newIndex) {
               context.read<SynthesisBloc>().add(
                     MoveSynthesisCard(
@@ -193,11 +198,12 @@ class _ConnectionsColumn extends StatelessWidget {
                   );
             },
             children: [
-              for (final card in cards)
+              for (int i = 0; i < cards.length; i++)
                 _ConnectionCard(
-                  key: ValueKey(card.id),
+                  key: ValueKey(cards[i].id),
+                  index: i,
                   columnKey: columnKey,
-                  card: card,
+                  card: cards[i],
                   color: color,
                 ),
             ],
@@ -209,12 +215,14 @@ class _ConnectionsColumn extends StatelessWidget {
 }
 
 class _ConnectionCard extends StatelessWidget {
+  final int index;
   final String columnKey;
   final SynthesisCard card;
   final Color color;
 
   const _ConnectionCard({
     super.key,
+    required this.index,
     required this.columnKey,
     required this.card,
     required this.color,
@@ -254,7 +262,10 @@ class _ConnectionCard extends StatelessWidget {
       ),
       child: ListTile(
         dense: true,
-        leading: Icon(Icons.drag_indicator, color: theme.colorScheme.outline),
+        leading: ReorderableDragStartListener(
+          index: index,
+          child: Icon(Icons.drag_indicator, color: theme.colorScheme.outline),
+        ),
         title: Text(card.text, style: theme.textTheme.bodyMedium),
         subtitle: Row(
           children: [

--- a/lib/features/values/widgets/values_definitions_view.dart
+++ b/lib/features/values/widgets/values_definitions_view.dart
@@ -125,7 +125,7 @@ class _ValuesDefinitionsViewState extends State<ValuesDefinitionsView> {
                                         index: index,
                                         child: const Padding(
                                           padding: EdgeInsets.only(right: 8),
-                                          child: Icon(Icons.drag_handle, color: Colors.grey, size: 24),
+                                          child: Icon(Icons.drag_indicator, color: Colors.grey, size: 24),
                                         ),
                                       ),
                                       Expanded(

--- a/lib/features/values/widgets/values_editor.dart
+++ b/lib/features/values/widgets/values_editor.dart
@@ -7,7 +7,7 @@ import 'values_rating_view.dart';
 import 'values_definitions_view.dart';
 import 'values_reflection_view.dart';
 
-class ValuesEditor extends StatelessWidget {
+class ValuesEditor extends StatefulWidget {
   final int currentStep;
   final ValueChanged<int> onStepTapped;
 
@@ -18,49 +18,80 @@ class ValuesEditor extends StatelessWidget {
   });
 
   @override
+  State<ValuesEditor> createState() => _ValuesEditorState();
+}
+
+// Flutter's Stepper (horizontal) rendert Kopfzeile (Nummern-Kreise) und
+// Step-Inhalt als EINEN gemeinsamen, intern scrollenden Block - es gibt
+// keine Möglichkeit, zwischen beiden eigenen fixen Inhalt einzufügen. Das
+// Fortschritts-Widget muss aber sowohl unter der Kopfzeile sitzen als auch
+// beim Scrollen sichtbar bleiben (#56). Lösung: als Positioned-Overlay direkt
+// unter der Kopfzeile rendern (deren Höhe bei diesem Stepper ohne
+// stepIconHeight/Step.label immer exakt 72px beträgt, siehe
+// flutter/material/stepper.dart) und dessen eigene, gemessene Höhe der
+// Werteliste als Top-Padding mitgeben, damit der Erklärtext nicht darunter
+// verschwindet.
+class _ValuesEditorState extends State<ValuesEditor> {
+  static const double _stepperHeaderHeight = 72;
+  final GlobalKey _bannerKey = GlobalKey();
+  double _bannerHeight = 0;
+
+  void _measureBanner() {
+    final renderBox = _bannerKey.currentContext?.findRenderObject() as RenderBox?;
+    final height = renderBox?.size.height ?? 0;
+    if (height > 0 && height != _bannerHeight) {
+      setState(() => _bannerHeight = height);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    if (widget.currentStep == 0) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _measureBanner();
+      });
+    }
 
-    return Column(
+    return Stack(
       children: [
-        // Fix oberhalb des Steppers statt Teil von Step 1s Inhalt (#56):
-        // Flutter's horizontales Stepper-Widget legt den Inhalt jedes Steps in
-        // eine eigene scrollbare ListView (nur die Nummern-Köpfe bleiben
-        // fix). Als Teil von ValuesRatingView scrollte der Fortschritt daher
-        // mit der Werteliste weg.
-        if (currentStep == 0) const _RatingProgressBanner(),
-        Expanded(
-          child: Theme(
-            data: Theme.of(context).copyWith(
-              canvasColor: Colors.transparent,
-            ),
-            child: Stepper(
-              type: StepperType.horizontal,
-              currentStep: currentStep,
-              onStepTapped: onStepTapped,
-              controlsBuilder: (context, details) => const SizedBox.shrink(),
-              steps: [
-                Step(
-                  title: _StepTitle(number: 1, fullLabel: l10n.valuesPhase1Title),
-                  content: const ValuesRatingView(),
-                  isActive: currentStep >= 0,
-                  state: currentStep > 0 ? StepState.complete : StepState.indexed,
-                ),
-                Step(
-                  title: _StepTitle(number: 2, fullLabel: l10n.valuesPhase2Title),
-                  content: const ValuesDefinitionsView(),
-                  isActive: currentStep >= 1,
-                  state: currentStep > 1 ? StepState.complete : StepState.indexed,
-                ),
-                Step(
-                  title: _StepTitle(number: 3, fullLabel: l10n.valuesPhase3Title),
-                  content: const ValuesReflectionView(),
-                  isActive: currentStep >= 2,
-                ),
-              ],
-            ),
+        Theme(
+          data: Theme.of(context).copyWith(
+            canvasColor: Colors.transparent,
+          ),
+          child: Stepper(
+            type: StepperType.horizontal,
+            currentStep: widget.currentStep,
+            onStepTapped: widget.onStepTapped,
+            controlsBuilder: (context, details) => const SizedBox.shrink(),
+            steps: [
+              Step(
+                title: _StepTitle(number: 1, fullLabel: l10n.valuesPhase1Title),
+                content: ValuesRatingView(topPadding: widget.currentStep == 0 ? _bannerHeight : 0),
+                isActive: widget.currentStep >= 0,
+                state: widget.currentStep > 0 ? StepState.complete : StepState.indexed,
+              ),
+              Step(
+                title: _StepTitle(number: 2, fullLabel: l10n.valuesPhase2Title),
+                content: const ValuesDefinitionsView(),
+                isActive: widget.currentStep >= 1,
+                state: widget.currentStep > 1 ? StepState.complete : StepState.indexed,
+              ),
+              Step(
+                title: _StepTitle(number: 3, fullLabel: l10n.valuesPhase3Title),
+                content: const ValuesReflectionView(),
+                isActive: widget.currentStep >= 2,
+              ),
+            ],
           ),
         ),
+        if (widget.currentStep == 0)
+          Positioned(
+            top: _stepperHeaderHeight,
+            left: 0,
+            right: 0,
+            child: _RatingProgressBanner(key: _bannerKey),
+          ),
       ],
     );
   }
@@ -69,7 +100,7 @@ class ValuesEditor extends StatelessWidget {
 /// Zeigt "X von 8 Werten bewertet" fix oberhalb der Werteliste, unabhängig
 /// vom Scroll-Zustand darin (#56).
 class _RatingProgressBanner extends StatelessWidget {
-  const _RatingProgressBanner();
+  const _RatingProgressBanner({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/values/widgets/values_editor.dart
+++ b/lib/features/values/widgets/values_editor.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:design_for_life/l10n/generated/app_localizations.dart';
+import '../bloc/values_bloc.dart';
+import '../bloc/values_state.dart';
 import 'values_rating_view.dart';
 import 'values_definitions_view.dart';
 import 'values_reflection_view.dart';
@@ -18,35 +21,93 @@ class ValuesEditor extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
 
-    return Theme(
-      data: Theme.of(context).copyWith(
-        canvasColor: Colors.transparent,
-      ),
-      child: Stepper(
-        type: StepperType.horizontal,
-        currentStep: currentStep,
-        onStepTapped: onStepTapped,
-        controlsBuilder: (context, details) => const SizedBox.shrink(),
-        steps: [
-          Step(
-            title: _StepTitle(number: 1, fullLabel: l10n.valuesPhase1Title),
-            content: const ValuesRatingView(),
-            isActive: currentStep >= 0,
-            state: currentStep > 0 ? StepState.complete : StepState.indexed,
+    return Column(
+      children: [
+        // Fix oberhalb des Steppers statt Teil von Step 1s Inhalt (#56):
+        // Flutter's horizontales Stepper-Widget legt den Inhalt jedes Steps in
+        // eine eigene scrollbare ListView (nur die Nummern-Köpfe bleiben
+        // fix). Als Teil von ValuesRatingView scrollte der Fortschritt daher
+        // mit der Werteliste weg.
+        if (currentStep == 0) const _RatingProgressBanner(),
+        Expanded(
+          child: Theme(
+            data: Theme.of(context).copyWith(
+              canvasColor: Colors.transparent,
+            ),
+            child: Stepper(
+              type: StepperType.horizontal,
+              currentStep: currentStep,
+              onStepTapped: onStepTapped,
+              controlsBuilder: (context, details) => const SizedBox.shrink(),
+              steps: [
+                Step(
+                  title: _StepTitle(number: 1, fullLabel: l10n.valuesPhase1Title),
+                  content: const ValuesRatingView(),
+                  isActive: currentStep >= 0,
+                  state: currentStep > 0 ? StepState.complete : StepState.indexed,
+                ),
+                Step(
+                  title: _StepTitle(number: 2, fullLabel: l10n.valuesPhase2Title),
+                  content: const ValuesDefinitionsView(),
+                  isActive: currentStep >= 1,
+                  state: currentStep > 1 ? StepState.complete : StepState.indexed,
+                ),
+                Step(
+                  title: _StepTitle(number: 3, fullLabel: l10n.valuesPhase3Title),
+                  content: const ValuesReflectionView(),
+                  isActive: currentStep >= 2,
+                ),
+              ],
+            ),
           ),
-          Step(
-            title: _StepTitle(number: 2, fullLabel: l10n.valuesPhase2Title),
-            content: const ValuesDefinitionsView(),
-            isActive: currentStep >= 1,
-            state: currentStep > 1 ? StepState.complete : StepState.indexed,
+        ),
+      ],
+    );
+  }
+}
+
+/// Zeigt "X von 8 Werten bewertet" fix oberhalb der Werteliste, unabhängig
+/// vom Scroll-Zustand darin (#56).
+class _RatingProgressBanner extends StatelessWidget {
+  const _RatingProgressBanner();
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return BlocBuilder<ValuesBloc, ValuesState>(
+      builder: (context, state) {
+        final top8Count = state.topEightValues.length;
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+          child: Card(
+            color: top8Count == 8 ? Colors.green.shade50 : Colors.blue.shade50,
+            child: Padding(
+              padding: const EdgeInsets.all(12.0),
+              child: Row(
+                children: [
+                  Icon(
+                    top8Count == 8 ? Icons.check_circle : Icons.info_outline,
+                    color: top8Count == 8 ? Colors.green : Colors.blue,
+                    size: 20,
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      l10n.valuesSelectionStatus(top8Count),
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.bold,
+                        color: top8Count > 8 ? Colors.red : null,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
           ),
-          Step(
-            title: _StepTitle(number: 3, fullLabel: l10n.valuesPhase3Title),
-            content: const ValuesReflectionView(),
-            isActive: currentStep >= 2,
-          ),
-        ],
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/features/values/widgets/values_rating_view.dart
+++ b/lib/features/values/widgets/values_rating_view.dart
@@ -16,13 +16,14 @@ class ValuesRatingView extends StatelessWidget {
     
     return BlocBuilder<ValuesBloc, ValuesState>(
       builder: (context, state) {
-        final top8Count = state.topEightValues.length;
-        
+        // Das "X von 8 bewertet"-Fortschritts-Widget wird bewusst nicht mehr
+        // hier gerendert, sondern fix oberhalb dieser Liste in ValuesEditor
+        // platziert, damit es beim Scrollen sichtbar bleibt (#56).
         return ListView.builder(
           padding: EdgeInsets.zero,
           shrinkWrap: true,
           physics: const NeverScrollableScrollPhysics(),
-          itemCount: state.allValues.length + 2,
+          itemCount: state.allValues.length + 1,
           itemBuilder: (context, index) {
             if (index == 0) {
               return Padding(
@@ -33,38 +34,7 @@ class ValuesRatingView extends StatelessWidget {
                 ),
               );
             }
-            if (index == 1) {
-              return Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: Card(
-                  color: top8Count == 8 ? Colors.green.shade50 : Colors.blue.shade50,
-                  child: Padding(
-                    padding: const EdgeInsets.all(12.0),
-                    child: Row(
-                      children: [
-                        Icon(
-                          top8Count == 8 ? Icons.check_circle : Icons.info_outline,
-                          color: top8Count == 8 ? Colors.green : Colors.blue,
-                          size: 20,
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: Text(
-                            l10n.valuesSelectionStatus(top8Count),
-                            style: TextStyle(
-                              fontSize: 13,
-                              fontWeight: FontWeight.bold,
-                              color: top8Count > 8 ? Colors.red : null,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              );
-            }
-            final valueIndex = index - 2;
+            final valueIndex = index - 1;
             final value = state.allValues[valueIndex];
             final isEven = valueIndex % 2 == 0;
             final backgroundColor = isEven

--- a/lib/features/values/widgets/values_rating_view.dart
+++ b/lib/features/values/widgets/values_rating_view.dart
@@ -7,13 +7,18 @@ import '../bloc/values_state.dart';
 import '../models/value_item.dart';
 
 class ValuesRatingView extends StatelessWidget {
-  const ValuesRatingView({super.key});
+  // Reservierter Platz oben, damit der fix als Overlay über dieser Liste
+  // schwebende Fortschritts-Banner den Erklärtext nicht verdeckt (#56) -
+  // wird von ValuesEditor mit dessen tatsächlich gemessener Höhe befüllt.
+  final double topPadding;
+
+  const ValuesRatingView({super.key, this.topPadding = 0});
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
-    
+
     return BlocBuilder<ValuesBloc, ValuesState>(
       builder: (context, state) {
         // Das "X von 8 bewertet"-Fortschritts-Widget wird bewusst nicht mehr
@@ -27,7 +32,7 @@ class ValuesRatingView extends StatelessWidget {
           itemBuilder: (context, index) {
             if (index == 0) {
               return Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                padding: EdgeInsets.fromLTRB(16, topPadding + 8, 16, 8),
                 child: Text(
                   l10n.valuesPhase1Guidance,
                   style: const TextStyle(fontStyle: FontStyle.italic),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -107,6 +107,8 @@
   "giftsRating5": "Sehr stark",
   "giftsRankingTitle": "Deine Gaben-Rangliste",
   "giftsRankingGuidance": "Tippe auf eine Gabe, um Details und Bibelstellen zu sehen. Deine Top 3 werden automatisch übernommen.",
+  "giftsDormantHeading": "Latente Gaben",
+  "giftsDormantGuidance": "Diese Gaben sind ebenfalls stark ausgeprägt, aber (noch) nicht unter deinen Top 3.",
   "giftsScorePoints": "{score} Pkt.",
   "@giftsScorePoints": {
     "placeholders": {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -109,6 +109,7 @@
   "giftsRankingGuidance": "Tippe auf eine Gabe, um Details und Bibelstellen zu sehen. Deine Top 3 werden automatisch übernommen.",
   "giftsDormantHeading": "Latente Gaben",
   "giftsDormantGuidance": "Diese Gaben sind ebenfalls stark ausgeprägt, aber (noch) nicht unter deinen Top 3.",
+  "giftsOtherHeading": "Weitere Gaben",
   "giftsScorePoints": "{score} Pkt.",
   "@giftsScorePoints": {
     "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -109,6 +109,7 @@
   "giftsRankingGuidance": "Tap on a gift to see details and Bible references. Your Top 3 will be automatically included.",
   "giftsDormantHeading": "Dormant Gifts",
   "giftsDormantGuidance": "These gifts are also strongly present, but not (yet) among your top 3.",
+  "giftsOtherHeading": "Other Gifts",
   "giftsScorePoints": "{score} pts.",
   "@giftsScorePoints": {
     "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -107,6 +107,8 @@
   "giftsRating5": "Very strongly",
   "giftsRankingTitle": "Your Spiritual Gifts Ranking",
   "giftsRankingGuidance": "Tap on a gift to see details and Bible references. Your Top 3 will be automatically included.",
+  "giftsDormantHeading": "Dormant Gifts",
+  "giftsDormantGuidance": "These gifts are also strongly present, but not (yet) among your top 3.",
   "giftsScorePoints": "{score} pts.",
   "@giftsScorePoints": {
     "placeholders": {

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -566,6 +566,18 @@ abstract class AppLocalizations {
   /// **'Tap on a gift to see details and Bible references. Your Top 3 will be automatically included.'**
   String get giftsRankingGuidance;
 
+  /// No description provided for @giftsDormantHeading.
+  ///
+  /// In en, this message translates to:
+  /// **'Dormant Gifts'**
+  String get giftsDormantHeading;
+
+  /// No description provided for @giftsDormantGuidance.
+  ///
+  /// In en, this message translates to:
+  /// **'These gifts are also strongly present, but not (yet) among your top 3.'**
+  String get giftsDormantGuidance;
+
   /// No description provided for @giftsScorePoints.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -578,6 +578,12 @@ abstract class AppLocalizations {
   /// **'These gifts are also strongly present, but not (yet) among your top 3.'**
   String get giftsDormantGuidance;
 
+  /// No description provided for @giftsOtherHeading.
+  ///
+  /// In en, this message translates to:
+  /// **'Other Gifts'**
+  String get giftsOtherHeading;
+
   /// No description provided for @giftsScorePoints.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -275,6 +275,9 @@ class AppLocalizationsDe extends AppLocalizations {
       'Diese Gaben sind ebenfalls stark ausgeprägt, aber (noch) nicht unter deinen Top 3.';
 
   @override
+  String get giftsOtherHeading => 'Weitere Gaben';
+
+  @override
   String giftsScorePoints(int score) {
     return '$score Pkt.';
   }

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -268,6 +268,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Tippe auf eine Gabe, um Details und Bibelstellen zu sehen. Deine Top 3 werden automatisch übernommen.';
 
   @override
+  String get giftsDormantHeading => 'Latente Gaben';
+
+  @override
+  String get giftsDormantGuidance =>
+      'Diese Gaben sind ebenfalls stark ausgeprägt, aber (noch) nicht unter deinen Top 3.';
+
+  @override
   String giftsScorePoints(int score) {
     return '$score Pkt.';
   }

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -272,6 +272,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'These gifts are also strongly present, but not (yet) among your top 3.';
 
   @override
+  String get giftsOtherHeading => 'Other Gifts';
+
+  @override
   String giftsScorePoints(int score) {
     return '$score pts.';
   }

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -265,6 +265,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Tap on a gift to see details and Bible references. Your Top 3 will be automatically included.';
 
   @override
+  String get giftsDormantHeading => 'Dormant Gifts';
+
+  @override
+  String get giftsDormantGuidance =>
+      'These gifts are also strongly present, but not (yet) among your top 3.';
+
+  @override
   String giftsScorePoints(int score) {
     return '$score pts.';
   }


### PR DESCRIPTION
## Summary

Fünf kleinere, aus fortgesetztem Testen entstandene Bugs/Verbesserungen (Prio 1 zuerst).

- fixes #61 Lebensbaum-Vollbildmodus: Kind/Geschwister hinzufügen wirkte erst nach Verlassen des Vollbildmodus, weil die Vollbild-Ansicht nicht an den Bloc angebunden war (kein BlocBuilder, nur ein einmaliger Snapshot beim Öffnen).
- fixes #56 Werte-Editor: "X von 8 bewertet"-Fortschritts-Widget scrollte mit der Werteliste weg (steckte im scrollenden Step-Inhalt des Steppers). Jetzt fix oberhalb platziert.
- fixes #60 Verknüpfungen zeigte zwei Drag-Handles pro Karte (eigenes vorne + automatisches von Flutter hinten). App-weit auf ein einziges, vorne liegendes Handle vereinheitlicht.
- fixes #59 Gabentest-Resultview: Top-3-Gaben und "latente" Gaben (Rang 4-6) waren visuell nicht unterschieden. Jetzt mit Abstand, eigener Überschrift, Kurzbeschreibung bei Top-3, und latente Gaben werden beim Teilen/Export mit eingebunden.
- feat #55 Lebensbaum: Teilbäume sind jetzt über einen +/- Button pro Knoten ein-/ausklappbar (nutzt die im graphview-Paket eingebaute Collapse/Expand-Unterstützung). Rein visuell, keine Auswirkung auf gespeicherte Daten oder Sharing/Export.

## Test plan
- [x] `flutter analyze` clean nach jeder Änderung (nur bekannte, vorbestehende Hinweise)
- [x] `flutter test` grün nach jeder Änderung (bis auf den bekannten, vorbestehenden `widget_test.dart`-Fehler)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>