### PR TITLE
Phase 5: collapsible life tree (retry) + open Bible references

### DIFF
--- a/lib/core/services/bible_reference_service.dart
+++ b/lib/core/services/bible_reference_service.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:design_for_life/l10n/generated/app_localizations.dart';
+
+/// Öffnet Bibelstellen-Angaben (z.B. "1. Kor 12,8" / "1 Cor 12:8") direkt in
+/// einer passenden externen Bibel-App/-Website statt nichts zu tun (#64).
+/// Deutsch geht nach bibleserver.com (dort ist die Luther-Übersetzung mit
+/// deutschen Buchnamen verlinkbar), Englisch nach bible.com/YouVersion
+/// (universeller USFM-Buchcode). Zentral hier statt pro Modul, damit z.B.
+/// auch andere Module (Predigt-Notizen, Andachten) dieselbe Logik nutzen
+/// können.
+class BibleReferenceService {
+  const BibleReferenceService._();
+
+  static Future<void> open(BuildContext context, String reference) async {
+    final uri = buildUriForTest(reference, Localizations.localeOf(context).languageCode);
+    final l10n = AppLocalizations.of(context);
+    if (uri == null || !await launchUrl(uri, mode: LaunchMode.externalApplication)) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l10n.bibleReferenceOpenFailed(reference))),
+        );
+      }
+    }
+  }
+
+  @visibleForTesting
+  static Uri? buildUriForTest(String reference, String languageCode) {
+    final match = RegExp(r'^((?:[123]\.?\s*)?[A-Za-zÀ-ÿ]+)\s+(\d+)(?:[,:–-]\s*(\d+))?')
+        .firstMatch(reference.trim());
+    if (match == null) return null;
+
+    final bookKey = match.group(1)!.replaceAll('.', '').replaceAll(' ', '').toUpperCase();
+    final chapter = match.group(2)!;
+    final verse = match.group(3);
+
+    if (languageCode == 'de') {
+      final slug = _bibleserverBooks[bookKey];
+      if (slug == null) return null;
+      final path = verse != null ? '$slug$chapter,$verse' : '$slug$chapter';
+      return Uri.https('www.bibleserver.com', '/LUT/$path');
+    }
+
+    final usfm = _bibleComBooks[bookKey];
+    if (usfm == null) return null;
+    final path = verse != null ? '/bible/111/$usfm.$chapter.$verse.NIV' : '/bible/111/$usfm.$chapter.NIV';
+    return Uri.https('www.bible.com', path);
+  }
+
+  // Deutsch: Buch-Abkürzung (wie in den Gaben-Datensätzen verwendet) ->
+  // bibleserver.com-Buchname. Nur die Bücher, die aktuell in den
+  // .arb/Datenquellen tatsächlich vorkommen; bei Bedarf einfach ergänzen.
+  static const Map<String, String> _bibleserverBooks = {
+    '1KOR': '1.Korinther',
+    '2KOR': '2.Korinther',
+    'JAK': 'Jakobus',
+    '1KÖN': '1.Könige',
+    'EX': '2.Mose',
+    'SPR': 'Sprüche',
+    'MT': 'Matthäus',
+    'HEBR': 'Hebräer',
+    'APG': 'Apostelgeschichte',
+    'MK': 'Markus',
+    'RÖM': 'Römer',
+    '1THESS': '1.Thessalonicher',
+    '1JOH': '1.Johannes',
+    '1PETR': '1.Petrus',
+    'EPH': 'Epheser',
+    '1TIM': '1.Timotheus',
+    '2TIM': '2.Timotheus',
+    'GAL': 'Galater',
+    'JOH': 'Johannes',
+  };
+
+  // Englisch: Buch-Abkürzung -> universeller 3-Buchstaben-USFM-Code
+  // (bible.com/YouVersion-URLs basieren darauf, unabhängig von der Übersetzung).
+  static const Map<String, String> _bibleComBooks = {
+    '1COR': '1CO',
+    '2COR': '2CO',
+    'JAS': 'JAS',
+    '1KGS': '1KI',
+    'EX': 'EXO',
+    'PROV': 'PRO',
+    'MATT': 'MAT',
+    'HEB': 'HEB',
+    'ACTS': 'ACT',
+    'MARK': 'MRK',
+    'ROM': 'ROM',
+    '1THESS': '1TH',
+    '1JOHN': '1JN',
+    '1PET': '1PE',
+    'EPH': 'EPH',
+    '1TIM': '1TI',
+    '2TIM': '2TI',
+    'GAL': 'GAL',
+    'JOHN': 'JHN',
+  };
+}

--- a/lib/core/widgets/dfl_entry_widget.dart
+++ b/lib/core/widgets/dfl_entry_widget.dart
@@ -95,19 +95,27 @@ class _DflEntryWidgetState extends State<DflEntryWidget> {
                 Column(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
+                    // constraints/padding waren zuvor auf BoxConstraints()
+                    // (praktisch nur die 20px große Icon-Fläche selbst)
+                    // reduziert - auf Android-Geräten führte das zu
+                    // unzuverlässigem Tippen, da der Tap-Bereich weit unter
+                    // der empfohlenen Mindestgröße lag. 40x40 ist ein
+                    // Kompromiss: deutlich zuverlässiger, ohne die Zeilenhöhe
+                    // (durch IntrinsicHeight an das Textfeld gekoppelt) zu
+                    // stark aufzublähen.
                     if (widget.onDelete != null)
                       IconButton(
                         icon: const Icon(Icons.close, size: 20, color: Colors.black54),
                         onPressed: widget.onDelete,
                         padding: EdgeInsets.zero,
-                        constraints: const BoxConstraints(),
+                        constraints: const BoxConstraints(minWidth: 40, minHeight: 40),
                         visualDensity: VisualDensity.compact,
                       ),
                     IconButton(
                       icon: const Icon(Icons.add_a_photo_outlined, size: 22),
                       onPressed: () => _pickImage(context),
                       padding: EdgeInsets.zero,
-                      constraints: const BoxConstraints(),
+                      constraints: const BoxConstraints(minWidth: 40, minHeight: 40),
                       visualDensity: VisualDensity.compact,
                     ),
                   ],
@@ -127,8 +135,12 @@ class _DflEntryWidgetState extends State<DflEntryWidget> {
                     top: 8,
                     child: GestureDetector(
                       onTap: () => widget.onImageChanged(null),
+                      // Frei über dem Bild positioniert (kein Einfluss auf
+                      // Zeilenhöhen o.ä.), daher hier ohne Kompromiss auf einen
+                      // zuverlässig tippbaren Bereich vergrößert (#Android-
+                      // Tap-Zuverlässigkeit).
                       child: Container(
-                        padding: const EdgeInsets.all(4),
+                        padding: const EdgeInsets.all(10),
                         decoration: const BoxDecoration(color: Colors.black54, shape: BoxShape.circle),
                         child: const Icon(Icons.close, color: Colors.white, size: 16),
                       ),

--- a/lib/features/export/services/export_content_builder.dart
+++ b/lib/features/export/services/export_content_builder.dart
@@ -218,9 +218,22 @@ class ExportContentBuilder {
     // durcheinandergewürfelten Baum im Export führte. Stattdessen die
     // umfangreichste Liste wählen - das ist praktisch immer der echte,
     // vollständige Baum, während Karteileichen nur wenige Knoten enthalten.
-    final nodes = state.treeNodes.values.fold<List<LifeTreeNodeData>>(
+    String? bestSessionId;
+    final rawNodes = state.treeNodes.entries.fold<List<LifeTreeNodeData>>(
       const [],
-      (best, current) => current.length > best.length ? current : best,
+      (best, entry) {
+        if (entry.value.length > best.length) {
+          bestSessionId = entry.key;
+          return entry.value;
+        }
+        return best;
+      },
+    );
+    // Eingeklappte Teilbäume bleiben auch im Export verborgen (#55), z.B. um
+    // persönliche Äste nicht in ein geteiltes PDF gelangen zu lassen.
+    final nodes = visibleLifeTreeNodes(
+      rawNodes,
+      state.collapsedNodeIds[bestSessionId] ?? const {},
     );
     if (takeaways.isEmpty && entries.isEmpty && nodes.isEmpty) return null;
 

--- a/lib/features/life_tree/bloc/life_tree_bloc.dart
+++ b/lib/features/life_tree/bloc/life_tree_bloc.dart
@@ -5,11 +5,17 @@ import '../models/life_tree_node_data.dart';
 
 class LifeTreeState extends EntryListState {
   final Map<String, List<LifeTreeNodeData>> treeNodes;
+  // Eingeklappte Teilbäume pro Session (#55) - bewusst im (hydrated)
+  // Bloc-State statt nur lokal im Editor-Widget, damit derselbe Zustand auch
+  // in der Ergebnisansicht und beim Teilen/Export gilt (z.B. um persönliche
+  // Äste dort zu verbergen) und über App-Neustarts hinweg erhalten bleibt.
+  final Map<String, Set<String>> collapsedNodeIds;
 
   const LifeTreeState({
     super.entries = const {},
     super.takeaways = const {},
     this.treeNodes = const {},
+    this.collapsedNodeIds = const {},
   });
 
   @override
@@ -26,11 +32,13 @@ class LifeTreeState extends EntryListState {
     Map<String, List<DflEntry>>? entries,
     Map<String, List<String>>? takeaways,
     Map<String, List<LifeTreeNodeData>>? treeNodes,
+    Map<String, Set<String>>? collapsedNodeIds,
   }) {
     return LifeTreeState(
       entries: entries ?? this.entries,
       takeaways: takeaways ?? this.takeaways,
       treeNodes: treeNodes ?? this.treeNodes,
+      collapsedNodeIds: collapsedNodeIds ?? this.collapsedNodeIds,
     );
   }
 
@@ -38,6 +46,7 @@ class LifeTreeState extends EntryListState {
   Map<String, dynamic> toJson() {
     final json = super.toJson();
     json['treeNodes'] = treeNodes.map((k, v) => MapEntry(k, v.map((e) => e.toJson()).toList()));
+    json['collapsedNodeIds'] = collapsedNodeIds.map((k, v) => MapEntry(k, v.toList()));
     return json;
   }
 
@@ -46,16 +55,20 @@ class LifeTreeState extends EntryListState {
     final treeNodes = (json['treeNodes'] as Map<String, dynamic>?)?.map(
           (k, v) => MapEntry(k, (v as List).map((e) => LifeTreeNodeData.fromJson(e)).toList()),
         ) ?? {};
-    
+    final collapsedNodeIds = (json['collapsedNodeIds'] as Map<String, dynamic>?)?.map(
+          (k, v) => MapEntry(k, (v as List).cast<String>().toSet()),
+        ) ?? {};
+
     return LifeTreeState(
       entries: base.entries,
       takeaways: base.takeaways,
       treeNodes: treeNodes,
+      collapsedNodeIds: collapsedNodeIds,
     );
   }
 
   @override
-  List<Object?> get props => [...super.props, treeNodes];
+  List<Object?> get props => [...super.props, treeNodes, collapsedNodeIds];
 }
 
 abstract class LifeTreeEvent extends EntryListEvent {
@@ -97,12 +110,21 @@ class DeleteTreeNode extends LifeTreeEvent {
   List<Object?> get props => [sessionId, nodeId];
 }
 
+class ToggleTreeNodeCollapsed extends LifeTreeEvent {
+  final String sessionId;
+  final String nodeId;
+  const ToggleTreeNodeCollapsed(this.sessionId, this.nodeId);
+  @override
+  List<Object?> get props => [sessionId, nodeId];
+}
+
 class LifeTreeBloc extends EntryListBloc {
   LifeTreeBloc() : super(const LifeTreeState()) {
     on<AddTreeNode>(_onAddTreeNode);
     on<UpdateTreeNodeText>(_onUpdateTreeNodeText);
     on<UpdateTreeNodeNote>(_onUpdateTreeNodeNote);
     on<DeleteTreeNode>(_onDeleteTreeNode);
+    on<ToggleTreeNodeCollapsed>(_onToggleTreeNodeCollapsed);
   }
 
   @override
@@ -151,6 +173,16 @@ class LifeTreeBloc extends EntryListBloc {
     final newMap = Map<String, List<LifeTreeNodeData>>.from(state.treeNodes);
     newMap[event.sessionId] = nodes;
     emit(state.copyWith(treeNodes: newMap));
+  }
+
+  void _onToggleTreeNodeCollapsed(ToggleTreeNodeCollapsed event, Emitter<EntryListState> emit) {
+    final collapsed = Set<String>.from(state.collapsedNodeIds[event.sessionId] ?? const {});
+    if (!collapsed.remove(event.nodeId)) {
+      collapsed.add(event.nodeId);
+    }
+    final newMap = Map<String, Set<String>>.from(state.collapsedNodeIds);
+    newMap[event.sessionId] = collapsed;
+    emit(state.copyWith(collapsedNodeIds: newMap));
   }
 
   @override

--- a/lib/features/life_tree/models/life_tree_node_data.dart
+++ b/lib/features/life_tree/models/life_tree_node_data.dart
@@ -47,3 +47,28 @@ class LifeTreeNodeData extends Equatable {
   @override
   List<Object?> get props => [id, text, note, parentId];
 }
+
+/// Filtert Knoten heraus, deren Elternkette (irgendwo weiter oben) einen
+/// eingeklappten Knoten enthält (#55). Gemeinsam genutzt vom Editor, der
+/// Ergebnisansicht und dem PDF-Export, damit ein eingeklappter Teilbaum
+/// überall gleichermaßen verborgen bleibt (z.B. um persönliche Äste vor dem
+/// Teilen zu verbergen), statt nur lokal im Editor sichtbar zu sein.
+List<LifeTreeNodeData> visibleLifeTreeNodes(
+  List<LifeTreeNodeData> nodes,
+  Set<String> collapsedNodeIds,
+) {
+  if (collapsedNodeIds.isEmpty) return nodes;
+  final byId = {for (final n in nodes) n.id: n};
+  bool isHidden(LifeTreeNodeData node) {
+    var current = node;
+    while (current.parentId != null) {
+      if (collapsedNodeIds.contains(current.parentId)) return true;
+      final parent = byId[current.parentId];
+      if (parent == null) break;
+      current = parent;
+    }
+    return false;
+  }
+
+  return nodes.where((n) => !isHidden(n)).toList();
+}

--- a/lib/features/life_tree/screens/life_tree_screen.dart
+++ b/lib/features/life_tree/screens/life_tree_screen.dart
@@ -85,6 +85,14 @@ class _LifeTreeScreenState extends State<LifeTreeScreen> {
         final entries = lifeTreeState.entries[widget.sessionId] ?? [];
         final takeaways = lifeTreeState.takeaways[widget.sessionId] ?? const ['', '', ''];
         final nodes = lifeTreeState.treeNodes[widget.sessionId] ?? [];
+        // In der Ergebnisansicht/beim Teilen bleiben eingeklappte Teilbäume
+        // verborgen (#55) - z.B. um persönliche Äste vor anderen zu
+        // verbergen. Der Editor selbst filtert unabhängig davon nochmal
+        // selbst, da dort auch das Auf-/Zuklappen bedient wird.
+        final visibleNodes = visibleLifeTreeNodes(
+          nodes,
+          lifeTreeState.collapsedNodeIds[widget.sessionId] ?? const {},
+        );
 
         final displayEntries = entries.isEmpty 
             ? [DflEntry(id: 'initial_${widget.sessionId}')] 
@@ -93,7 +101,7 @@ class _LifeTreeScreenState extends State<LifeTreeScreen> {
         return DflModuleScaffold(
           title: widget.title,
           initialEditMode: widget.initialEditMode,
-          shareableContent: _getShareableContent(context, entries, takeaways, nodes),
+          shareableContent: _getShareableContent(context, entries, takeaways, visibleNodes),
           onShare: (selectedItems) async {
             Uint8List? capturedImage;
             
@@ -126,7 +134,7 @@ class _LifeTreeScreenState extends State<LifeTreeScreen> {
 
               ShareService.shareContent(
                 context: context,
-                content: _getShareableContent(context, entries, takeaways, nodes),
+                content: _getShareableContent(context, entries, takeaways, visibleNodes),
                 selectedItems: enrichedItems
               );
             }
@@ -142,7 +150,7 @@ class _LifeTreeScreenState extends State<LifeTreeScreen> {
           result: LifeTreeResult(
             entries: entries,
             takeaways: takeaways,
-            nodes: nodes,
+            nodes: visibleNodes,
             screenshotController: _screenshotController,
             onUpdate: (index, value) => context.read<LifeTreeBloc>().add(UpdateTakeaway(widget.sessionId, index, value)),
           ),

--- a/lib/features/life_tree/widgets/life_tree_editor.dart
+++ b/lib/features/life_tree/widgets/life_tree_editor.dart
@@ -203,6 +203,13 @@ class _LifeTreeGraphViewOnlyState extends State<_LifeTreeGraphViewOnly> with Tic
   late BuchheimWalkerConfiguration builder;
   late Algorithm algorithm;
   final Map<String, Node> _nodeCache = {};
+  // Ein-/Ausklappen von Teilbäumen (#55) - bewusst eine eigene, einfache
+  // Sichtbarkeits-Filterung statt graphviews eingebautem GraphViewController:
+  // dieser verursachte in einem früheren Anlauf zwei verschiedene
+  // Render-Abstürze (NaN beim Zeichnen, dann unendliche Größe beim Layout).
+  // Hier werden eingeklappte Teilbäume stattdessen einfach nie an den Graph
+  // übergeben, die einfache/stabile GraphView()-Variante bleibt unverändert.
+  final Set<String> _collapsedNodeIds = {};
   late TransformationController _transformationController;
   late AnimationController _animationController;
   Animation<Matrix4>? _animation;
@@ -298,9 +305,31 @@ class _LifeTreeGraphViewOnlyState extends State<_LifeTreeGraphViewOnly> with Tic
     }
   }
 
+  /// Knoten, deren Elternkette (irgendwo weiter oben) einen eingeklappten
+  /// Knoten enthält, werden komplett aus dem Graph herausgefiltert - sie
+  /// werden nie an graphview übergeben, statt sie (fehleranfällig) über
+  /// dessen eigene Sichtbarkeits-/Animationslogik zu verbergen.
+  List<LifeTreeNodeData> _computeVisibleNodes() {
+    if (_collapsedNodeIds.isEmpty) return widget.nodes;
+    final byId = {for (final n in widget.nodes) n.id: n};
+    bool isHidden(LifeTreeNodeData node) {
+      var current = node;
+      while (current.parentId != null) {
+        if (_collapsedNodeIds.contains(current.parentId)) return true;
+        final parent = byId[current.parentId];
+        if (parent == null) break;
+        current = parent;
+      }
+      return false;
+    }
+
+    return widget.nodes.where((n) => !isHidden(n)).toList();
+  }
+
   void _syncGraph() {
-    final Set<String> targetIds = widget.nodes.map((n) => n.id).toSet();
-    
+    final visibleNodes = _computeVisibleNodes();
+    final Set<String> targetIds = visibleNodes.map((n) => n.id).toSet();
+
     final currentNodes = List<Node>.from(graph.nodes);
     for (var node in currentNodes) {
       final id = node.key?.value as String;
@@ -310,7 +339,7 @@ class _LifeTreeGraphViewOnlyState extends State<_LifeTreeGraphViewOnly> with Tic
       }
     }
 
-    for (var nodeData in widget.nodes) {
+    for (var nodeData in visibleNodes) {
       final node = _nodeCache.putIfAbsent(nodeData.id, () => Node.Id(nodeData.id));
       if (!graph.nodes.contains(node)) {
         graph.addNode(node);
@@ -318,7 +347,7 @@ class _LifeTreeGraphViewOnlyState extends State<_LifeTreeGraphViewOnly> with Tic
     }
 
     graph.edges.clear();
-    for (var nodeData in widget.nodes) {
+    for (var nodeData in visibleNodes) {
       if (nodeData.parentId != null) {
         final parent = _nodeCache[nodeData.parentId];
         final child = _nodeCache[nodeData.id];
@@ -327,6 +356,15 @@ class _LifeTreeGraphViewOnlyState extends State<_LifeTreeGraphViewOnly> with Tic
         }
       }
     }
+  }
+
+  void _toggleCollapse(String nodeId) {
+    setState(() {
+      if (!_collapsedNodeIds.remove(nodeId)) {
+        _collapsedNodeIds.add(nodeId);
+      }
+      _syncGraph();
+    });
   }
 
   @override
@@ -372,11 +410,15 @@ class _LifeTreeGraphViewOnlyState extends State<_LifeTreeGraphViewOnly> with Tic
               builder: (Node node) {
                 final nodeId = node.key?.value as String;
                 final nodeData = widget.nodes.firstWhere((n) => n.id == nodeId, orElse: () => LifeTreeNodeData(id: nodeId, text: '...'));
+                final hasChildren = widget.nodes.any((n) => n.parentId == nodeId);
 
                 return _TreeNodeWidget(
                   key: ValueKey('node_wid_$nodeId'),
                   nodeData: nodeData,
                   autofocus: nodeId == _lastAddedNodeId,
+                  hasChildren: hasChildren,
+                  isCollapsed: hasChildren && _collapsedNodeIds.contains(nodeId),
+                  onToggleCollapse: () => _toggleCollapse(nodeId),
                   onChanged: (text) => widget.onUpdateText(nodeId, text),
                   onNoteChanged: (note) => widget.onUpdateNote(nodeId, note),
                   onAddChild: () => widget.onAddNode(nodeId, ''),
@@ -477,6 +519,9 @@ class _FullscreenGraphViewerState extends State<_FullscreenGraphViewer> {
 class _TreeNodeWidget extends StatefulWidget {
   final LifeTreeNodeData nodeData;
   final bool autofocus;
+  final bool hasChildren;
+  final bool isCollapsed;
+  final VoidCallback onToggleCollapse;
   final ValueChanged<String> onChanged;
   final ValueChanged<String> onNoteChanged;
   final VoidCallback onAddChild;
@@ -487,6 +532,9 @@ class _TreeNodeWidget extends StatefulWidget {
     super.key,
     required this.nodeData,
     this.autofocus = false,
+    this.hasChildren = false,
+    this.isCollapsed = false,
+    required this.onToggleCollapse,
     required this.onChanged,
     required this.onNoteChanged,
     required this.onAddChild,
@@ -758,6 +806,19 @@ class _TreeNodeWidgetState extends State<_TreeNodeWidget> {
                     onTap: widget.onDelete,
                   ),
                 ),
+
+              // Ein-/Ausklappen von Teilbäumen (#55): bewusst immer sichtbar
+              // (nicht nur bei Hover wie die übrigen Buttons), damit erkennbar
+              // bleibt, dass hier weitere Knoten verborgen sind, auch ohne
+              // dass man gerade über den Knoten fährt.
+              if (widget.hasChildren)
+                Positioned(
+                  bottom: -12,
+                  child: _CollapseToggleButton(
+                    isCollapsed: widget.isCollapsed,
+                    onTap: widget.onToggleCollapse,
+                  ),
+                ),
             ],
           ),
         ),
@@ -786,6 +847,38 @@ class _GhostNodeButton extends StatelessWidget {
         child: Text(
           label,
           style: TextStyle(fontSize: 10, color: Colors.grey.shade700, fontWeight: FontWeight.bold),
+        ),
+      ),
+    );
+  }
+}
+
+/// Ein-/Ausklappen von Teilbäumen (#55): kleiner runder Button unterhalb
+/// eines Knotens mit Kindern, zeigt je nach Zustand + oder -.
+class _CollapseToggleButton extends StatelessWidget {
+  final bool isCollapsed;
+  final VoidCallback onTap;
+
+  const _CollapseToggleButton({required this.isCollapsed, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Material(
+      color: Colors.white,
+      shape: CircleBorder(side: BorderSide(color: theme.primaryColor.withValues(alpha: 0.5))),
+      elevation: 1,
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        onTap: onTap,
+        child: SizedBox(
+          width: 24,
+          height: 24,
+          child: Icon(
+            isCollapsed ? Icons.add : Icons.remove,
+            size: 16,
+            color: theme.primaryColor,
+          ),
         ),
       ),
     );

--- a/lib/features/life_tree/widgets/life_tree_editor.dart
+++ b/lib/features/life_tree/widgets/life_tree_editor.dart
@@ -36,10 +36,12 @@ class LifeTreeEditor extends DflModuleEditor {
           key: ValueKey('graph_section_$sessionId'),
           sessionId: sessionId,
           nodes: nodes,
+          collapsedNodeIds: lifeTreeBloc.state.collapsedNodeIds[sessionId] ?? const {},
           onAddNode: (parentId, text) => lifeTreeBloc.add(AddTreeNode(sessionId, parentId: parentId, text: text)),
           onUpdateText: (nodeId, text) => lifeTreeBloc.add(UpdateTreeNodeText(sessionId, nodeId, text)),
           onUpdateNote: (nodeId, note) => lifeTreeBloc.add(UpdateTreeNodeNote(sessionId, nodeId, note)),
           onDeleteNode: (nodeId) => lifeTreeBloc.add(DeleteTreeNode(sessionId, nodeId)),
+          onToggleCollapse: (nodeId) => lifeTreeBloc.add(ToggleTreeNodeCollapsed(sessionId, nodeId)),
         ),
         const SizedBox(height: 32),
         const Divider(),
@@ -70,19 +72,23 @@ class LifeTreeEditor extends DflModuleEditor {
 class _LifeTreeGraphSection extends StatefulWidget {
   final String sessionId;
   final List<LifeTreeNodeData> nodes;
+  final Set<String> collapsedNodeIds;
   final Function(String?, String) onAddNode;
   final Function(String, String) onUpdateText;
   final Function(String, String) onUpdateNote;
   final Function(String) onDeleteNode;
+  final Function(String) onToggleCollapse;
 
   const _LifeTreeGraphSection({
     super.key,
     required this.sessionId,
     required this.nodes,
+    required this.collapsedNodeIds,
     required this.onAddNode,
     required this.onUpdateText,
     required this.onUpdateNote,
     required this.onDeleteNode,
+    required this.onToggleCollapse,
   });
 
   @override
@@ -153,10 +159,12 @@ class _LifeTreeGraphSectionState extends State<_LifeTreeGraphSection> {
                 ),
                 child: _LifeTreeGraphViewOnly(
                   nodes: widget.nodes,
+                  collapsedNodeIds: widget.collapsedNodeIds,
                   onAddNode: widget.onAddNode,
                   onUpdateText: widget.onUpdateText,
                   onUpdateNote: widget.onUpdateNote,
                   onDeleteNode: widget.onDeleteNode,
+                  onToggleCollapse: widget.onToggleCollapse,
                   transformationController: _transformationController,
                 ),
               ),
@@ -179,18 +187,22 @@ class _LifeTreeGraphSectionState extends State<_LifeTreeGraphSection> {
 
 class _LifeTreeGraphViewOnly extends StatefulWidget {
   final List<LifeTreeNodeData> nodes;
+  final Set<String> collapsedNodeIds;
   final Function(String?, String) onAddNode;
   final Function(String, String) onUpdateText;
   final Function(String, String) onUpdateNote;
   final Function(String) onDeleteNode;
+  final Function(String) onToggleCollapse;
   final TransformationController? transformationController;
 
   const _LifeTreeGraphViewOnly({
     required this.nodes,
+    this.collapsedNodeIds = const {},
     required this.onAddNode,
     required this.onUpdateText,
     required this.onUpdateNote,
     required this.onDeleteNode,
+    required this.onToggleCollapse,
     this.transformationController,
   });
 
@@ -203,13 +215,6 @@ class _LifeTreeGraphViewOnlyState extends State<_LifeTreeGraphViewOnly> with Tic
   late BuchheimWalkerConfiguration builder;
   late Algorithm algorithm;
   final Map<String, Node> _nodeCache = {};
-  // Ein-/Ausklappen von Teilbäumen (#55) - bewusst eine eigene, einfache
-  // Sichtbarkeits-Filterung statt graphviews eingebautem GraphViewController:
-  // dieser verursachte in einem früheren Anlauf zwei verschiedene
-  // Render-Abstürze (NaN beim Zeichnen, dann unendliche Größe beim Layout).
-  // Hier werden eingeklappte Teilbäume stattdessen einfach nie an den Graph
-  // übergeben, die einfache/stabile GraphView()-Variante bleibt unverändert.
-  final Set<String> _collapsedNodeIds = {};
   late TransformationController _transformationController;
   late AnimationController _animationController;
   Animation<Matrix4>? _animation;
@@ -253,11 +258,13 @@ class _LifeTreeGraphViewOnlyState extends State<_LifeTreeGraphViewOnly> with Tic
           orElse: () => widget.nodes.last,
         );
         _lastAddedNodeId = newNode.id;
-        
+
         WidgetsBinding.instance.addPostFrameCallback((_) {
           _scrollToNode(newNode.id);
         });
       }
+      _syncGraph();
+    } else if (widget.collapsedNodeIds != oldWidget.collapsedNodeIds) {
       _syncGraph();
     }
   }
@@ -305,29 +312,8 @@ class _LifeTreeGraphViewOnlyState extends State<_LifeTreeGraphViewOnly> with Tic
     }
   }
 
-  /// Knoten, deren Elternkette (irgendwo weiter oben) einen eingeklappten
-  /// Knoten enthält, werden komplett aus dem Graph herausgefiltert - sie
-  /// werden nie an graphview übergeben, statt sie (fehleranfällig) über
-  /// dessen eigene Sichtbarkeits-/Animationslogik zu verbergen.
-  List<LifeTreeNodeData> _computeVisibleNodes() {
-    if (_collapsedNodeIds.isEmpty) return widget.nodes;
-    final byId = {for (final n in widget.nodes) n.id: n};
-    bool isHidden(LifeTreeNodeData node) {
-      var current = node;
-      while (current.parentId != null) {
-        if (_collapsedNodeIds.contains(current.parentId)) return true;
-        final parent = byId[current.parentId];
-        if (parent == null) break;
-        current = parent;
-      }
-      return false;
-    }
-
-    return widget.nodes.where((n) => !isHidden(n)).toList();
-  }
-
   void _syncGraph() {
-    final visibleNodes = _computeVisibleNodes();
+    final visibleNodes = visibleLifeTreeNodes(widget.nodes, widget.collapsedNodeIds);
     final Set<String> targetIds = visibleNodes.map((n) => n.id).toSet();
 
     final currentNodes = List<Node>.from(graph.nodes);
@@ -356,15 +342,6 @@ class _LifeTreeGraphViewOnlyState extends State<_LifeTreeGraphViewOnly> with Tic
         }
       }
     }
-  }
-
-  void _toggleCollapse(String nodeId) {
-    setState(() {
-      if (!_collapsedNodeIds.remove(nodeId)) {
-        _collapsedNodeIds.add(nodeId);
-      }
-      _syncGraph();
-    });
   }
 
   @override
@@ -417,8 +394,8 @@ class _LifeTreeGraphViewOnlyState extends State<_LifeTreeGraphViewOnly> with Tic
                   nodeData: nodeData,
                   autofocus: nodeId == _lastAddedNodeId,
                   hasChildren: hasChildren,
-                  isCollapsed: hasChildren && _collapsedNodeIds.contains(nodeId),
-                  onToggleCollapse: () => _toggleCollapse(nodeId),
+                  isCollapsed: hasChildren && widget.collapsedNodeIds.contains(nodeId),
+                  onToggleCollapse: () => widget.onToggleCollapse(nodeId),
                   onChanged: (text) => widget.onUpdateText(nodeId, text),
                   onNoteChanged: (note) => widget.onUpdateNote(nodeId, note),
                   onAddChild: () => widget.onAddNode(nodeId, ''),
@@ -500,13 +477,18 @@ class _FullscreenGraphViewerState extends State<_FullscreenGraphViewer> {
         // neu (#61).
         child: BlocBuilder<LifeTreeBloc, EntryListState>(
           builder: (context, state) {
-            final nodes = (state as LifeTreeState).treeNodes[widget.sessionId] ?? const [];
+            final lifeTreeState = state as LifeTreeState;
+            final nodes = lifeTreeState.treeNodes[widget.sessionId] ?? const [];
+            final collapsedNodeIds = lifeTreeState.collapsedNodeIds[widget.sessionId] ?? const {};
             return _LifeTreeGraphViewOnly(
               nodes: nodes,
+              collapsedNodeIds: collapsedNodeIds,
               onAddNode: widget.onAddNode,
               onUpdateText: widget.onUpdateText,
               onUpdateNote: widget.onUpdateNote,
               onDeleteNode: widget.onDeleteNode,
+              onToggleCollapse: (nodeId) =>
+                  context.read<LifeTreeBloc>().add(ToggleTreeNodeCollapsed(widget.sessionId, nodeId)),
               transformationController: _transformationController,
             );
           },
@@ -638,73 +620,106 @@ class _TreeNodeWidgetState extends State<_TreeNodeWidget> {
               Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Container(
-                    decoration: BoxDecoration(
-                      color: Colors.white,
-                      borderRadius: BorderRadius.circular(8),
-                      border: Border.all(
-                        color: _textFocusNode.hasFocus ? theme.primaryColor : Colors.grey.shade300,
-                        width: _textFocusNode.hasFocus ? 2 : 1,
-                      ),
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withValues(alpha: 0.05), 
-                          blurRadius: 4, 
-                          offset: const Offset(0, 2)
-                        ),
-                      ],
-                    ),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Row(
-                          children: [
-                            Expanded(
-                              child: TextField(
-                                controller: _textController,
-                                focusNode: _textFocusNode,
-                                decoration: InputDecoration(
-                                  isDense: true, 
-                                  border: InputBorder.none, 
-                                  contentPadding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-                                  hintText: l10n.lifeTreeNodeHint,
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      // Ein-/Ausklappen von Teilbäumen (#55): bewusst immer
+                      // sichtbar (nicht nur bei Hover wie die übrigen
+                      // Buttons), damit erkennbar bleibt, dass hier weitere
+                      // Knoten verborgen sind. Als echtes Layout-Element (statt
+                      // per Positioned mit negativem Offset außerhalb der
+                      // Karte) reserviert, weil ein per Positioned nach links
+                      // über den Rand der Karte hinausragender Bereich zwar
+                      // gezeichnet, aber laut Flutters Hit-Test-Logik nur
+                      // innerhalb der eigenen (Karten-)Größe antippbar ist -
+                      // die linke Hälfte des Kreises reagierte dadurch nicht
+                      // auf Taps. Immer reservierte, gleich breite Spalte
+                      // (auch ohne Kinder), damit alle Karten links bündig
+                      // bleiben. Während der Notiz-Editor offen ist, wird der
+                      // Button ausgeblendet, damit er das Notiz-Popup nicht
+                      // verdeckt.
+                      SizedBox(
+                        width: 28,
+                        child: (widget.hasChildren && !_showNoteOverlay)
+                            ? Center(
+                                child: _CollapseToggleButton(
+                                  isCollapsed: widget.isCollapsed,
+                                  onTap: widget.onToggleCollapse,
                                 ),
-                                style: theme.textTheme.bodyMedium,
-                                onSubmitted: (val) => widget.onChanged(val),
+                              )
+                            : null,
+                      ),
+                      Expanded(
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: Colors.white,
+                            borderRadius: BorderRadius.circular(8),
+                            border: Border.all(
+                              color: _textFocusNode.hasFocus ? theme.primaryColor : Colors.grey.shade300,
+                              width: _textFocusNode.hasFocus ? 2 : 1,
+                            ),
+                            boxShadow: [
+                              BoxShadow(
+                                color: Colors.black.withValues(alpha: 0.05),
+                                blurRadius: 4,
+                                offset: const Offset(0, 2)
                               ),
-                            ),
-                            Visibility(
-                              visible: showButtons,
-                              maintainSize: true,
-                              maintainAnimation: true,
-                              maintainState: true,
-                              child: IconButton(
-                                icon: Icon(Icons.speaker_notes, size: 16, color: theme.primaryColor.withValues(alpha: 0.6)),
-                                onPressed: () {
-                                  setState(() => _showNoteOverlay = !_showNoteOverlay);
-                                  if (_showNoteOverlay) {
-                                    _noteFocusNode.requestFocus();
-                                  }
-                                },
-                                constraints: const BoxConstraints(),
-                                padding: const EdgeInsets.only(right: 8),
-                                tooltip: l10n.lifeTreeEditNote,
-                              ),
-                            ),
-                          ],
-                        ),
-                        if (!_showNoteOverlay && widget.nodeData.note.isNotEmpty)
-                          Padding(
-                            padding: const EdgeInsets.only(left: 10, right: 10, bottom: 6),
-                            child: Text(
-                              widget.nodeData.note,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: const TextStyle(fontSize: 10, fontStyle: FontStyle.italic, color: Colors.grey),
-                            ),
+                            ],
                           ),
-                      ],
-                    ),
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Row(
+                                children: [
+                                  Expanded(
+                                    child: TextField(
+                                      controller: _textController,
+                                      focusNode: _textFocusNode,
+                                      decoration: InputDecoration(
+                                        isDense: true,
+                                        border: InputBorder.none,
+                                        contentPadding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+                                        hintText: l10n.lifeTreeNodeHint,
+                                      ),
+                                      style: theme.textTheme.bodyMedium,
+                                      onSubmitted: (val) => widget.onChanged(val),
+                                    ),
+                                  ),
+                                  Visibility(
+                                    visible: showButtons,
+                                    maintainSize: true,
+                                    maintainAnimation: true,
+                                    maintainState: true,
+                                    child: IconButton(
+                                      icon: Icon(Icons.speaker_notes, size: 16, color: theme.primaryColor.withValues(alpha: 0.6)),
+                                      onPressed: () {
+                                        setState(() => _showNoteOverlay = !_showNoteOverlay);
+                                        if (_showNoteOverlay) {
+                                          _noteFocusNode.requestFocus();
+                                        }
+                                      },
+                                      constraints: const BoxConstraints(),
+                                      padding: const EdgeInsets.only(right: 8),
+                                      tooltip: l10n.lifeTreeEditNote,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              if (!_showNoteOverlay && widget.nodeData.note.isNotEmpty)
+                                Padding(
+                                  padding: const EdgeInsets.only(left: 10, right: 10, bottom: 6),
+                                  child: Text(
+                                    widget.nodeData.note,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: const TextStyle(fontSize: 10, fontStyle: FontStyle.italic, color: Colors.grey),
+                                  ),
+                                ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
                   const SizedBox(height: 4),
                   Visibility(
@@ -798,25 +813,17 @@ class _TreeNodeWidgetState extends State<_TreeNodeWidget> {
                 ),
 
               if (showButtons && widget.nodeData.parentId != null)
+                // Um 8px verschoben, um die zusätzliche (unsichtbare)
+                // Tap-Fläche von _GhostNodeButton auszugleichen - die
+                // sichtbare "x"-Chip landet dadurch an derselben Stelle wie
+                // zuvor, nur mit einem größeren, zuverlässiger tippbaren
+                // Bereich drumherum (Android-Tap-Zuverlässigkeit).
                 Positioned(
-                  top: -8,
-                  right: -8,
+                  top: -16,
+                  right: -16,
                   child: _GhostNodeButton(
                     label: 'x',
                     onTap: widget.onDelete,
-                  ),
-                ),
-
-              // Ein-/Ausklappen von Teilbäumen (#55): bewusst immer sichtbar
-              // (nicht nur bei Hover wie die übrigen Buttons), damit erkennbar
-              // bleibt, dass hier weitere Knoten verborgen sind, auch ohne
-              // dass man gerade über den Knoten fährt.
-              if (widget.hasChildren)
-                Positioned(
-                  bottom: -12,
-                  child: _CollapseToggleButton(
-                    isCollapsed: widget.isCollapsed,
-                    onTap: widget.onToggleCollapse,
                   ),
                 ),
             ],
@@ -837,16 +844,24 @@ class _GhostNodeButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return InkWell(
       onTap: onTap,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-        decoration: BoxDecoration(
-          color: Colors.grey.shade100,
-          borderRadius: BorderRadius.circular(4),
-          border: Border.all(color: Colors.grey.shade300),
-        ),
-        child: Text(
-          label,
-          style: TextStyle(fontSize: 10, color: Colors.grey.shade700, fontWeight: FontWeight.bold),
+      borderRadius: BorderRadius.circular(4),
+      // Die sichtbare Chip-Fläche allein war auf Android unzuverlässig
+      // tippbar (v.a. bei der einzeln stehenden "x"-Löschen-Chip); 8px
+      // unsichtbares Padding rundherum vergrößert den Tap-Bereich, ohne den
+      // sichtbaren Chip selbst zu verändern.
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: BoxDecoration(
+            color: Colors.grey.shade100,
+            borderRadius: BorderRadius.circular(4),
+            border: Border.all(color: Colors.grey.shade300),
+          ),
+          child: Text(
+            label,
+            style: TextStyle(fontSize: 10, color: Colors.grey.shade700, fontWeight: FontWeight.bold),
+          ),
         ),
       ),
     );

--- a/lib/features/spiritual_gifts/widgets/spiritual_gifts_result.dart
+++ b/lib/features/spiritual_gifts/widgets/spiritual_gifts_result.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:design_for_life/l10n/generated/app_localizations.dart';
+import '../../../core/services/bible_reference_service.dart';
 import '../bloc/spiritual_gifts_bloc.dart';
 import '../models/spiritual_gift.dart';
 
@@ -274,9 +275,7 @@ class _GiftDetailSheet extends StatelessWidget {
                     runSpacing: 8,
                     children: gift.bibleReferences.map((ref) => ActionChip(
                       label: Text(ref, style: const TextStyle(fontSize: 12)),
-                      onPressed: () {
-                        // Logic for external link
-                      },
+                      onPressed: () => BibleReferenceService.open(context, ref),
                       avatar: const Icon(Icons.menu_book, size: 14),
                       backgroundColor: theme.colorScheme.surfaceContainerHighest,
                     )).toList(),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -119,6 +119,12 @@
   "giftsMeaning": "Bedeutung",
   "giftsDescription": "Beschreibung",
   "giftsBibleReferences": "Bibelstellen",
+  "bibleReferenceOpenFailed": "Konnte \"{reference}\" nicht öffnen",
+  "@bibleReferenceOpenFailed": {
+    "placeholders": {
+      "reference": { "type": "String" }
+    }
+  },
   "giftsIncompleteTitle": "Test unvollständig",
   "giftsIncompleteMessage": "Du hast erst {answered} von {total} Fragen beantwortet. Möchtest du den Test wirklich abschließen?",
   "@giftsIncompleteMessage": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -119,6 +119,12 @@
   "giftsMeaning": "Meaning",
   "giftsDescription": "Description",
   "giftsBibleReferences": "Bible References",
+  "bibleReferenceOpenFailed": "Could not open \"{reference}\"",
+  "@bibleReferenceOpenFailed": {
+    "placeholders": {
+      "reference": { "type": "String" }
+    }
+  },
   "giftsIncompleteTitle": "Test Incomplete",
   "giftsIncompleteMessage": "You have only answered {answered} out of {total} questions. Do you really want to finish the test?",
   "@giftsIncompleteMessage": {

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -608,6 +608,12 @@ abstract class AppLocalizations {
   /// **'Bible References'**
   String get giftsBibleReferences;
 
+  /// No description provided for @bibleReferenceOpenFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not open \"{reference}\"'**
+  String bibleReferenceOpenFailed(String reference);
+
   /// No description provided for @giftsIncompleteTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -292,6 +292,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get giftsBibleReferences => 'Bibelstellen';
 
   @override
+  String bibleReferenceOpenFailed(String reference) {
+    return 'Konnte \"$reference\" nicht öffnen';
+  }
+
+  @override
   String get giftsIncompleteTitle => 'Test unvollständig';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -289,6 +289,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get giftsBibleReferences => 'Bible References';
 
   @override
+  String bibleReferenceOpenFailed(String reference) {
+    return 'Could not open \"$reference\"';
+  }
+
+  @override
   String get giftsIncompleteTitle => 'Test Incomplete';
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -746,6 +746,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.32"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -754,6 +778,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
   url_launcher_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   printing: ^5.13.4
 
   http: ^1.2.0
+  url_launcher: ^6.3.0
 
 dev_dependencies:
   flutter_test:

--- a/test/bible_reference_service_test.dart
+++ b/test/bible_reference_service_test.dart
@@ -1,0 +1,46 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:design_for_life/core/services/bible_reference_service.dart';
+
+void main() {
+  List<String> referencesFrom(String path) {
+    final data = jsonDecode(File(path).readAsStringSync()) as List;
+    return data
+        .expand((gift) => (gift['bibleReferences'] as List).cast<String>())
+        .toSet()
+        .toList();
+  }
+
+  test('every DE gift bible reference resolves to a bibleserver.com URI', () {
+    for (final ref in referencesFrom('assets/data/gifts_de.json')) {
+      final uri = BibleReferenceService.buildUriForTest(ref, 'de');
+      expect(uri, isNotNull, reason: 'Could not parse/map reference "$ref"');
+      expect(uri!.host, 'www.bibleserver.com');
+    }
+  });
+
+  test('every EN gift bible reference resolves to a bible.com URI', () {
+    for (final ref in referencesFrom('assets/data/gifts_en.json')) {
+      final uri = BibleReferenceService.buildUriForTest(ref, 'en');
+      expect(uri, isNotNull, reason: 'Could not parse/map reference "$ref"');
+      expect(uri!.host, 'www.bible.com');
+    }
+  });
+
+  test('builds a verse-specific link when a verse is present', () {
+    final uri = BibleReferenceService.buildUriForTest('1. Kor 12,8', 'de');
+    expect(uri.toString(), 'https://www.bibleserver.com/LUT/1.Korinther12,8');
+  });
+
+  test('falls back to the whole chapter when no verse is given', () {
+    final uri = BibleReferenceService.buildUriForTest('Hebr 11', 'de');
+    expect(uri.toString(), 'https://www.bibleserver.com/LUT/Hebr%C3%A4er11');
+  });
+
+  test('unknown book returns null instead of a broken link', () {
+    final uri = BibleReferenceService.buildUriForTest('Nichtsburg 3,1', 'de');
+    expect(uri, isNull);
+  });
+}


### PR DESCRIPTION
## Summary

- feat #55 Lebensbaum: Teilbäume ein-/ausklappbar (zweiter Anlauf) - diesmal ganz ohne graphviews GraphViewController/Animation, stattdessen eine eigene, einfache Sichtbarkeits-Filterung vor der Graph-Übergabe. Die beiden vorherigen Abstürze (NaN beim Zeichnen, dann unendliche Größe beim Layout) waren beide auf den Controller/die eingebaute Animation zurückzuführen; die einfache GraphView()-Variante bleibt jetzt komplett unangetastet.
- feat #64 Bibelstellen-Chips im Gabentest öffnen jetzt direkt extern (bibleserver.com für Deutsch, bible.com/YouVersion für Englisch), statt nichts zu tun. Zentral in einem wiederverwendbaren `BibleReferenceService`, damit andere Module das später auch nutzen können.

## Test plan
- [x] `flutter analyze` clean (nur bekannte, vorbestehende Hinweise in unberührten Dateien)
- [x] `flutter test` grün (bis auf den bekannten, vorbestehenden `widget_test.dart`-Fehler), inkl. 5 neuer Tests, die alle tatsächlich in gifts_de.json/gifts_en.json vorkommenden Bibelstellen-Referenzen gegen den Parser prüfen
- [x] Manuell auf echtem Gerät gegen die zwei vorherigen Lebensbaum-Abstürze getestet (siehe Commit-Historie)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>